### PR TITLE
fix: allow support for only providing the network id for ametnes_service

### DIFF
--- a/ametnes/resource_service.go
+++ b/ametnes/resource_service.go
@@ -152,6 +152,14 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	if networkIntf, ok := d.GetOk("network"); ok {
 		networkStr := networkIntf.(string)
+
+		// if there is a project id present as a prefix lets
+		// just remove it
+		if strings.Contains(networkStr, "/") {
+			networkParts := strings.Split(networkStr, "/")
+			// we remove the project id part
+			networkStr = networkParts[1]
+		}
 		networkInt, err := strconv.Atoi(networkStr)
 		if err != nil {
 			return diag.FromErr(err)


### PR DESCRIPTION
Fixes the below error

```
Error: strconv.Atoi: parsing "<project_id>/<network_id>": invalid syntax
│ 
│   with ametnes_service.grafana,
│   on main.tf line 34, in resource "ametnes_service" "grafana":
│   34: resource "ametnes_service" "grafana" {

```
