### PR TITLE
feat: make service capacity optional and drop cpu/memory/nodes sizing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,7 @@ on:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-      id-token: write
     steps:
-    - name: CargoWall
-      uses: code-cargo/cargowall-action@v1.2.0
     - name: Checkout
       uses: actions/checkout@v3
     - name: Unshallow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - In-place updates for `ametnes_service` (`name`, `description`, `capacity`,
-  `nodes`, `config`, `alias`) and `ametnes_network` (`name`, `description`,
+  `config`, `alias`) and `ametnes_network` (`name`, `description`,
   `config`) — these no longer force recreation.
 - `alias` attribute on `ametnes_service`.
 - Configurable `timeouts` blocks on `ametnes_service` (create `60m`, update
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   private load balancer provisioning.
 - `ametnes_service.network` is now optional; a network is auto-created when
   omitted.
-- `ametnes_service.nodes` now defaults to `1`.
 - `ametnes_service.config` defaults `public.visible` to `"true"` when unset.
 - Unit and mock tests for the client, status polling, resource create/update,
   and timeouts, plus a `make testunit` target.
@@ -35,11 +34,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ametnes_kinds` and `ametnes_network` data sources return clearer error
   messages and handle empty results.
 - Examples and docs switched to `for_each` maps with `random_string` aliases
-  and `architecture` presets; removed `memory = 1` / `cpu = 1` from example
-  capacity blocks.
+  and `architecture` presets; removed `cpu` and `memory` from capacity blocks
+  (sizing is now driven entirely by the architecture preset).
+- `storage` in the `capacity` block is optional — if omitted, the backend
+  assigns a default value — and the configured value is distributed across
+  the service's components in predetermined proportions.
 
 ### Removed
 - Redundant `network` (Number) field from the `ametnes_network` schema.
+- The `nodes` attribute from `ametnes_service`; the node count is now fixed
+  internally to `1` and driven by the architecture preset.
+- The `cpu` and `memory` attributes from the `ametnes_service` `capacity` block;
+  compute sizing is now driven by the architecture preset.
 
 ### Fixed
 - Documentation typos (`lcoation` → `location`, `creat` → `create`,

--- a/README.md
+++ b/README.md
@@ -1,21 +1,245 @@
-# Terraform Provider Hashicups
+# Terraform Provider Ametnes Cloud
 
-Run the following command to build the provider
+The Ametnes Cloud provider lets you manage [Ametnes Cloud](https://cloud.ametnes.com/)
+resources with Terraform: data service locations, projects, networks, and data services.
+
+An Ametnes Data Service location is a dedicated Kubernetes cluster with an Ametnes Cloud
+Agent installed. Data services are created and managed in the cluster using this provider.
+
+## Requirements
+
+- [Terraform](https://www.terraform.io/downloads) 0.13+
+- [Go](https://golang.org/dl/) 1.18+ (to build the provider from source)
+
+## Building and installing the provider
+
+Build the provider binary:
 
 ```shell
 go build -o terraform-provider-ametnes
 ```
 
-## Test sample configuration
-
-First, build and install the provider.
+Install it into your local Terraform plugins directory:
 
 ```shell
 make install
 ```
 
-Then, run the following command to initialize the workspace and apply the sample configuration.
+## Authentication
+
+To use this provider, generate an authentication token (aka API key) in your Ametnes Cloud
+account: `User` -> `Edit` your user -> `Get User Token`. Keep the token secure — it will not
+be visible again.
+
+Two variables are required:
+
+- `username` — the email address associated with your Ametnes Cloud account.
+- `token` — the API token generated in the Ametnes console under your user account.
+
+Supply them through any Terraform variable mechanism, for example `terraform.tfvars`:
+
+```hcl
+# terraform.tfvars
+token    = "your-api-token"
+username = "you@example.com"
+```
+
+## Example usage
+
+### Configure the provider
+
+```terraform
+terraform {
+  required_providers {
+    ametnes = {
+      source  = "ametnes.com/cloud/ametnes"
+    }
+  }
+}
+
+provider "ametnes" {
+  token    = var.token
+  username = var.username
+}
+
+variable "token" {
+  type = string
+}
+
+variable "username" {
+  type = string
+}
+```
+
+### Create a data service location
+
+A data service location hosts your data services. Alternatively, create one in the
+[Ametnes Cloud](https://cloud.ametnes.com/) console (`Service Locations` -> `New`) and note
+the location id.
+
+```terraform
+resource "ametnes_location" "location" {
+  name = "Ametnes Cloud"
+  code = "EUW1"
+}
+```
+
+### Create a project
+
+All Ametnes Cloud resources must be created in a project.
+
+```terraform
+resource "ametnes_project" "project" {
+  name        = "DemoProject"
+  description = "Demo project"
+}
+```
+
+### Create a network
+
+A network access resource exposes your data services. Depending on your Kubernetes cluster
+this may be a load balancer or a set of `NodePort`s. The `config` map accepts a `public` key:
+
+- `"public" = "true"` — provisions a public-facing load balancer (default behavior).
+- `"public" = "false"` — provisions a private load balancer accessible only within the network.
+
+```terraform
+resource "ametnes_network" "network" {
+  name        = "NETWORK-EUW8"
+  project     = data.ametnes_project.project.id
+  location    = data.ametnes_location.location.id
+  description = "My load balancer resource"
+  config = {
+    "public" = "true"
+  }
+}
+```
+
+### Create data services
+
+Provision multiple services using a map for stable resource addressing. The `network`
+attribute is optional — if omitted, a network is automatically created. Compute sizing
+(CPU/memory) is driven by the `architecture` preset in `config`. `storage` is optional too
+— if omitted, the backend assigns a default value — and the value you set is distributed
+across all the components that make up the service in predetermined proportions.
+
+```terraform
+terraform {
+  required_providers {
+    ametnes = {
+      source  = "ametnes.com/cloud/ametnes"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+# Look up an existing location.
+data "ametnes_location" "location" {
+  name = "Ametnes Cloud"
+  code = "EUW1"
+}
+
+# Look up an existing project.
+data "ametnes_project" "project" {
+  name = "Demo"
+}
+
+locals {
+  services = {
+    sentry = { kind = "sentry:26.2", kind_name = "sentry", storage = 30, architecture = "Starter" },
+    matomo = { kind = "matomo:5.9",  kind_name = "matomo", storage = 10, architecture = "Starter" },
+  }
+}
+
+resource "random_string" "service_alias" {
+  for_each = local.services
+  length   = 5
+  special  = false
+  upper    = false
+}
+
+resource "ametnes_service" "service" {
+  for_each = local.services
+  name     = "${each.value.kind_name}-service-${random_string.service_alias[each.key].result}"
+  project  = data.ametnes_project.project.id
+  location = data.ametnes_location.location.id
+  kind     = each.value.kind
+  alias    = random_string.service_alias[each.key].result
+  capacity {
+    storage = each.value.storage
+  }
+  config = {
+    architecture  = each.value.architecture
+    "admin.email" = var.username
+  }
+}
+
+output "service_connections" {
+  value = { for k, svc in ametnes_service.service : k => svc.connections }
+}
+```
+
+### Look up existing resources
+
+```terraform
+data "ametnes_project" "project" {
+  name = "Default"
+}
+
+data "ametnes_location" "location" {
+  name = "Ametnes"
+  code = "DSL-USE1"
+}
+
+data "ametnes_network" "network" {
+  name     = "NETWORK-EUW7"
+  project  = data.ametnes_project.project.id
+  location = data.ametnes_location.location.id
+}
+
+data "ametnes_kinds" "kinds" {
+}
+```
+
+## Timeouts
+
+The `timeouts` block controls how long the provider waits for a service or network to reach a
+stable state. The actual deployment is performed asynchronously by the Ametnes Cloud Agent,
+so the Terraform run must wait for the agent to finish before it completes.
+
+Defaults for `ametnes_service`: `create` 60m, `update` 45m, `delete` 10m.
+
+```terraform
+timeouts {
+  create = "60m"
+  update = "2h"
+  delete = "20m"
+}
+```
+
+## Documentation
+
+Full resource and data source reference:
+
+- [Provider](docs/index.md)
+- [ametnes_service](docs/resources/service.md)
+- [ametnes_network](docs/resources/network.md)
+- [ametnes_project](docs/resources/project.md)
+- [ametnes_location](docs/resources/location.md)
+
+## Development
+
+Run the unit tests:
 
 ```shell
-terraform init && terraform apply
+make testunit
+```
+
+Run the acceptance tests (requires `TF_ACC` and live credentials):
+
+```shell
+make testacc
 ```

--- a/ametnes/client_error_test.go
+++ b/ametnes/client_error_test.go
@@ -249,7 +249,6 @@ func TestResourceServiceCreate_FailsOnErrorState(t *testing.T) {
 		"location":    "gcp/europe-west2",
 		"network":     "1",
 		"description": "test",
-		"nodes":       1,
 		"config":      map[string]interface{}{},
 		"capacity":    []interface{}{},
 	})
@@ -328,8 +327,6 @@ func getMockClientForUpdate() (*Client, *httptest.Server) {
 				Network:     1,
 				Spec: Spec{
 					Components: map[string]interface{}{
-						"cpu":     1,
-						"memory":  1,
 						"storage": 1,
 					},
 					Nodes:   1,
@@ -378,7 +375,6 @@ func TestResourceServiceUpdate_WaitsForStatusAfterUpdate(t *testing.T) {
 		"kind":        "mysql:8.0",
 		"location":    "gcp/europe-west2",
 		"description": "test",
-		"nodes":       1,
 		"config":      map[string]interface{}{"key": "old-value"},
 		"capacity":    []interface{}{},
 		"alias":       "test-alias",
@@ -446,8 +442,6 @@ func TestResourceServiceCreate_DefaultsPublicVisibleToTrue(t *testing.T) {
 				Network:     1,
 				Spec: Spec{
 					Components: map[string]interface{}{
-						"cpu":     1,
-						"memory":  1,
 						"storage": 1,
 					},
 					Nodes:   1,
@@ -485,7 +479,6 @@ func TestResourceServiceCreate_DefaultsPublicVisibleToTrue(t *testing.T) {
 		"location":    "gcp/europe-west2",
 		"network":     "1",
 		"description": "test",
-		"nodes":       1,
 		"capacity":    []interface{}{},
 	})
 
@@ -527,8 +520,6 @@ func TestResourceServiceCreate_PreservesExplicitPublicVisible(t *testing.T) {
 				Network:     1,
 				Spec: Spec{
 					Components: map[string]interface{}{
-						"cpu":     1,
-						"memory":  1,
 						"storage": 1,
 					},
 					Nodes:   1,
@@ -566,7 +557,6 @@ func TestResourceServiceCreate_PreservesExplicitPublicVisible(t *testing.T) {
 		"location":    "gcp/europe-west2",
 		"network":     "1",
 		"description": "test",
-		"nodes":       1,
 		"config":      map[string]interface{}{"public.visible": "false"},
 		"capacity":    []interface{}{},
 	})
@@ -610,8 +600,6 @@ func TestResourceServiceCreate_DefaultsPublicVisibleWithNilConfig(t *testing.T) 
 				Network:     1,
 				Spec: Spec{
 					Components: map[string]interface{}{
-						"cpu":     1,
-						"memory":  1,
 						"storage": 1,
 					},
 					Nodes:   1,
@@ -649,7 +637,6 @@ func TestResourceServiceCreate_DefaultsPublicVisibleWithNilConfig(t *testing.T) 
 		"location":    "gcp/europe-west2",
 		"network":     "1",
 		"description": "test",
-		"nodes":       1,
 		"capacity":    []interface{}{},
 	})
 

--- a/ametnes/client_mock_test.go
+++ b/ametnes/client_mock_test.go
@@ -110,8 +110,6 @@ func GetMockClient(t *testing.T) (*Client, *httptest.Server) {
 						Network:     1,
 						Spec: Spec{
 							Components: map[string]interface{}{
-								"cpu":     1,
-								"memory":  1,
 								"storage": 1,
 							},
 							Nodes: 1,
@@ -138,8 +136,6 @@ func GetMockClient(t *testing.T) (*Client, *httptest.Server) {
 				Network:     1,
 				Spec: Spec{
 					Components: map[string]interface{}{
-						"cpu":     1,
-						"memory":  1,
 						"storage": 1,
 					},
 					Nodes: 1,

--- a/ametnes/client_unit_test.go
+++ b/ametnes/client_unit_test.go
@@ -83,8 +83,6 @@ func TestClient_CreateResource_Unit(t *testing.T) {
 		Name:     "New Resource",
 		Spec: Spec{
 			Components: map[string]interface{}{
-				"cpu":     1,
-				"memory":  1,
 				"storage": 1,
 			},
 			Nodes: 1,

--- a/ametnes/data_source_kind.go
+++ b/ametnes/data_source_kind.go
@@ -85,7 +85,7 @@ func dataSourceKinds() *schema.Resource {
 									},
 								},
 							},
-							Description: "Capacity limits for ths resource kind. These include `memory`, `cpu` and `storage` as well as the number of `nodes` that can be scaled to.",
+							Description: "Capacity limits for this resource kind. These include `storage` as well as the number of `nodes` that can be scaled to.",
 						},
 						"type": {
 							Type:     schema.TypeString,

--- a/ametnes/models.go
+++ b/ametnes/models.go
@@ -74,8 +74,6 @@ type Product struct {
 }
 
 type Capacity struct {
-	Cpu     int
-	Memory  int
 	Storage int
 }
 

--- a/ametnes/resource_network.go
+++ b/ametnes/resource_network.go
@@ -11,9 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const DefaultCpu = 1
 const DefaultStorage = 1
-const DefaultMemory = 1
 const DefaultNodes = 1
 
 func resourceNetwork() *schema.Resource {
@@ -120,9 +118,7 @@ func resourceNetworkCreate(ctx context.Context, d *schema.ResourceData, m interf
 		Description: description,
 		Spec: Spec{
 			Components: map[string]interface{}{
-				"cpu":     DefaultCpu,
 				"storage": DefaultStorage,
-				"memory":  DefaultMemory,
 			},
 			Nodes:  DefaultNodes,
 			Config: config,

--- a/ametnes/resource_service.go
+++ b/ametnes/resource_service.go
@@ -64,33 +64,16 @@ Creates and manages a data service resource. All data service resources created 
 				Required:    false,
 				Optional:    true,
 				MaxItems:    1,
-				Description: "Capacity specs for your data service resource.",
+				Description: "Capacity specs for your data service resource. Only `storage` is configurable.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"cpu": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Description: "Cpu, in unit counts, that your service resource needs.",
-						},
-
-						"memory": {
-							Type:        schema.TypeInt,
-							Optional:    true,
-							Description: "Memory, in (Gi) unit counts, that your service resource needs.",
-						},
 						"storage": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Description: "Storage, in (Gb) unit counts, that your service resource needs.",
+							Description: "Storage, in (Gb) unit counts, for your data service resource. Optional — if omitted, the backend assigns a default value. The value is distributed across all components that make up the service in predetermined proportions.",
 						},
 					},
 				},
-			},
-			"nodes": {
-				Type:        schema.TypeInt,
-				Optional:    true,
-				Default:     1,
-				Description: "Number of nodes for your data service resource. Defaults to `1` if not specified.",
 			},
 			"config": {
 				Type:        schema.TypeMap,
@@ -183,9 +166,6 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, m interf
 	}
 	d.Set("config", config)
 
-	// get nodes, defaults to 1 if not provided (via schema Default)
-	nodes := d.Get("nodes").(int)
-
 	alias := ""
 	if a, ok := d.GetOk("alias"); ok {
 		alias = a.(string)
@@ -203,11 +183,9 @@ func resourceServiceCreate(ctx context.Context, d *schema.ResourceData, m interf
 		Alias:       alias,
 		Spec: Spec{
 			Components: map[string]interface{}{
-				"cpu":     capacity.Cpu,
 				"storage": capacity.Storage,
-				"memory":  capacity.Memory,
 			},
-			Nodes:  nodes,
+			Nodes:  DefaultNodes,
 			Config: config,
 		},
 	}
@@ -263,8 +241,8 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interf
 	}
 
 	// Check if any updatable fields have changed
-	hasChanges := d.HasChange("name") || d.HasChange("description") || d.HasChange("capacity") || 
-		d.HasChange("nodes") || d.HasChange("config") || d.HasChange("alias")
+	hasChanges := d.HasChange("name") || d.HasChange("description") || d.HasChange("capacity") ||
+		d.HasChange("config") || d.HasChange("alias")
 
 	if hasChanges {
 		client := m.(*Client)
@@ -303,9 +281,6 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			return diag.FromErr(err)
 		}
 
-		// Get nodes, defaults to 1 if not provided
-		nodes := d.Get("nodes").(int)
-
 		// Get the config
 		var config map[string]interface{}
 		if v, ok := d.GetOk("config"); ok {
@@ -333,11 +308,9 @@ func resourceServiceUpdate(ctx context.Context, d *schema.ResourceData, m interf
 			Product:     existingResource.Product,
 			Spec: Spec{
 				Components: map[string]interface{}{
-					"cpu":     capacity.Cpu,
 					"storage": capacity.Storage,
-					"memory":  capacity.Memory,
 				},
-				Nodes:    nodes,
+				Nodes:    DefaultNodes,
 				Config:   config,
 				Networks: existingResource.Spec.Networks,
 			},
@@ -402,14 +375,10 @@ func resourceServiceOrNetworkRead(ctx context.Context, d *schema.ResourceData, m
 
 	// Set service-specific fields only for service resources
 	if strings.HasPrefix(resource.Kind, "service/") {
-		d.Set("nodes", resource.Spec.Nodes)
-
 		// Set capacity
 		if resource.Spec.Components != nil {
 			capacity := []map[string]interface{}{
 				{
-					"cpu":     resource.Spec.Components["cpu"],
-					"memory":  resource.Spec.Components["memory"],
 					"storage": resource.Spec.Components["storage"],
 				},
 			}
@@ -497,25 +466,9 @@ func resourceServiceOrNetworkDelete(ctx context.Context, d *schema.ResourceData,
 func expandCapacitySchema(in []interface{}) (*Capacity, error) {
 	cap := &Capacity{}
 	if len(in) == 0 || in[0] == nil {
-		return &Capacity{
-			Cpu:     1,
-			Memory:  1,
-			Storage: 1,
-		}, nil
+		return &Capacity{Storage: 1}, nil
 	}
 	m := in[0].(map[string]interface{})
-
-	if cpu, ok := m["cpu"]; ok {
-		cap.Cpu = cpu.(int)
-	} else {
-		cap.Cpu = 1
-	}
-
-	if mem, ok := m["memory"]; ok {
-		cap.Memory = mem.(int)
-	} else {
-		cap.Memory = 1
-	}
 
 	if storage, ok := m["storage"]; ok {
 		cap.Storage = storage.(int)

--- a/ametnes/resources_test.go
+++ b/ametnes/resources_test.go
@@ -39,8 +39,6 @@ func TestCreateAndGetResource_Unit(t *testing.T) {
 
 	spec := Spec{}
 	components := make(map[string]interface{})
-	components["cpu"] = 1
-	components["memory"] = 1
 	components["storage"] = 1
 
 	spec.Components = components
@@ -75,7 +73,6 @@ func TestResourceService_NetworkFieldImmutability(t *testing.T) {
 		"name":     "test-service",
 		"kind":     "mysql:8.0",
 		"location": "gcp/europe-west2",
-		"nodes":    1,
 		"network":  "123",
 	})
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,6 @@ resource "ametnes_service" "service" {
     architecture  = each.value.architecture
     "admin.email" = var.username
   }
-  nodes = 1
 }
 
 output "service_connections" {

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -8,7 +8,9 @@ description: |-
 
 # ametnes_service (Resource)
 
-Creates and manages a data service resource. The `network` attribute is optional; if omitted, a network resource is automatically created.
+Creates and manages a data service resource. The `network` attribute is optional; if omitted, a network resource is automatically created. Compute sizing (CPU/memory) is driven by the `architecture` preset in `config`.
+
+The `capacity` block only exposes `storage`. It is optional — if omitted, the backend assigns a default value — and the value you set is distributed across all the components that make up the service in predetermined proportions.
 
 ~> If resource creation fails (the resource enters `ERROR` state), the provider will fail immediately with an error. It does not wait for a timeout.
 
@@ -71,7 +73,6 @@ resource "ametnes_service" "service" {
     architecture  = each.value.architecture
     "admin.email" = var.username
   }
-  nodes = 1
 
   # Optional. Override the time the provider waits for the resource to
   # reach a stable state during create/update/delete. Useful for
@@ -101,11 +102,10 @@ output "service_connections" {
 ### Optional
 
 - `alias` (String) An optional alias for your data service resource.
-- `capacity` (Block List, Max: 1) Capacity specs for your data service resource. (see [below for nested schema](#nestedblock--capacity))
+- `capacity` (Block List, Max: 1) Capacity specs for your data service resource. Only `storage` is configurable. (see [below for nested schema](#nestedblock--capacity))
 - `config` (Map of String) Configuration details for your data service resource. Commonly used keys include `admin.email`, `admin.user`, `admin.password`, `architecture`, and service-specific configuration.
 - `description` (String) The description of your data service resource.
 - `network` (String, Optional) Network resource your data service resource will be attached to. If omitted, a network is automatically created.
-- `nodes` (Number) Number of nodes for your data service resource. Defaults to `1` if not specified.
 
 ### Read-Only
 
@@ -161,9 +161,7 @@ resource "ametnes_service" "service" {
 
 Optional:
 
-- `cpu` (Number) Cpu, in unit counts, that your service resource needs.
-- `memory` (Number) Memory, in (Gi) unit counts, that your service resource needs.
-- `storage` (Number) Storage, in (Gb) unit counts, that your service resource needs.
+- `storage` (Number) Storage, in (Gb) unit counts, for your data service resource. Optional — if omitted, the backend assigns a default value. The value is distributed across all components that make up the service in predetermined proportions.
 
 
 <a id="nestedatt--connections"></a>

--- a/examples/provider/example-resources.tf
+++ b/examples/provider/example-resources.tf
@@ -39,7 +39,6 @@ resource "ametnes_service" "service" {
     architecture  = each.value.architecture
     "admin.email" = var.username
   }
-  nodes = 1
 }
 
 output "service_connections" {

--- a/examples/resources/ametnes_service/resource.tf
+++ b/examples/resources/ametnes_service/resource.tf
@@ -42,7 +42,6 @@ resource "ametnes_service" "grafana" {
     "auth.azuread.client_secret" = "SomeText"
   }
  
-  nodes = 1
 
   timeouts {
     create = "60m"

--- a/examples/usage/network-service/main.tf
+++ b/examples/usage/network-service/main.tf
@@ -37,8 +37,6 @@ resource "ametnes_service" "hdb" {
   network = ametnes_network.network.resource_id
   capacity {
     storage = 100
-    memory = 4
-    cpu = 2
   }
 
   config = {
@@ -48,7 +46,6 @@ resource "ametnes_service" "hdb" {
     "clustering.password" = var.hdb_clustering_pass
   }
  
-  nodes = 1
 }
 
 output "hdb_connections" {

--- a/examples/usage/service/main.tf
+++ b/examples/usage/service/main.tf
@@ -46,7 +46,6 @@ resource "ametnes_service" "service" {
     "admin.email" = var.username
     "public.visible" = "true"
   }
-  nodes = 1
   timeouts {
     create = "3h"
     update = "3h"


### PR DESCRIPTION
Remove the `cpu`, `memory`, and `nodes` attributes from `ametnes_service`; compute sizing is now driven entirely by the architecture preset. The `capacity` block now exposes only an optional `storage` value, which the backend defaults when omitted.

- Remove `cpu` and `memory` from the `capacity` schema and `Capacity` model
- Remove the `nodes` attribute; node count is fixed to 1 internally
- Make `storage` optional and clarify it is distributed across components
- Update examples, docs, README, and CHANGELOG accordingly