### PR TITLE
chore: migrate goreleaser config to v2 and normalize docs punctuation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
 before:
@@ -51,4 +53,4 @@ release:
   # If you want to manually examine the release before it's live, uncomment this line:
   draft: true
 changelog:
-  skip: true
+  disable: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - In-place updates for `ametnes_service` (`name`, `description`, `capacity`,
   `config`, `alias`) and `ametnes_network` (`name`, `description`,
-  `config`) — these no longer force recreation.
+  `config`) - these no longer force recreation.
 - `alias` attribute on `ametnes_service`.
 - Configurable `timeouts` blocks on `ametnes_service` (create `60m`, update
   `45m`, delete `10m`) and `ametnes_network` (create `15m`, update `15m`,
@@ -36,8 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Examples and docs switched to `for_each` maps with `random_string` aliases
   and `architecture` presets; removed `cpu` and `memory` from capacity blocks
   (sizing is now driven entirely by the architecture preset).
-- `storage` in the `capacity` block is optional — if omitted, the backend
-  assigns a default value — and the configured value is distributed across
+- `storage` in the `capacity` block is optional - if omitted, the backend
+  assigns a default value - and the configured value is distributed across
   the service's components in predetermined proportions.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ make install
 ## Authentication
 
 To use this provider, generate an authentication token (aka API key) in your Ametnes Cloud
-account: `User` -> `Edit` your user -> `Get User Token`. Keep the token secure — it will not
+account: `User` -> `Edit` your user -> `Get User Token`. Keep the token secure - it will not
 be visible again.
 
 Two variables are required:
 
-- `username` — the email address associated with your Ametnes Cloud account.
-- `token` — the API token generated in the Ametnes console under your user account.
+- `username` - the email address associated with your Ametnes Cloud account.
+- `token` - the API token generated in the Ametnes console under your user account.
 
 Supply them through any Terraform variable mechanism, for example `terraform.tfvars`:
 
@@ -100,8 +100,8 @@ resource "ametnes_project" "project" {
 A network access resource exposes your data services. Depending on your Kubernetes cluster
 this may be a load balancer or a set of `NodePort`s. The `config` map accepts a `public` key:
 
-- `"public" = "true"` — provisions a public-facing load balancer (default behavior).
-- `"public" = "false"` — provisions a private load balancer accessible only within the network.
+- `"public" = "true"` - provisions a public-facing load balancer (default behavior).
+- `"public" = "false"` - provisions a private load balancer accessible only within the network.
 
 ```terraform
 resource "ametnes_network" "network" {
@@ -118,9 +118,9 @@ resource "ametnes_network" "network" {
 ### Create data services
 
 Provision multiple services using a map for stable resource addressing. The `network`
-attribute is optional — if omitted, a network is automatically created. Compute sizing
+attribute is optional - if omitted, a network is automatically created. Compute sizing
 (CPU/memory) is driven by the `architecture` preset in `config`. `storage` is optional too
-— if omitted, the backend assigns a default value — and the value you set is distributed
+- if omitted, the backend assigns a default value - and the value you set is distributed
 across all the components that make up the service in predetermined proportions.
 
 ```terraform

--- a/ametnes/resource_service.go
+++ b/ametnes/resource_service.go
@@ -70,7 +70,7 @@ Creates and manages a data service resource. All data service resources created 
 						"storage": {
 							Type:        schema.TypeInt,
 							Optional:    true,
-							Description: "Storage, in (Gb) unit counts, for your data service resource. Optional — if omitted, the backend assigns a default value. The value is distributed across all components that make up the service in predetermined proportions.",
+							Description: "Storage, in (Gb) unit counts, for your data service resource. Optional - if omitted, the backend assigns a default value. The value is distributed across all components that make up the service in predetermined proportions.",
 						},
 					},
 				},

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ data "ametnes_project" "project" {
 }
 
 # Provision multiple services using a map for stable resource addressing.
-# The network attribute is optional — if omitted, a network is auto-created.
+# The network attribute is optional - if omitted, a network is auto-created.
 locals {
   services = {
     sentry = { kind = "sentry:26.2", kind_name = "sentry", storage = 30, architecture = "Starter" },

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -14,8 +14,8 @@ Creates and manages a network access resource. Depending on your kubernetes clus
 
 The `config` map accepts a `public` key:
 
-- `"public" = "true"` — Provisions a public-facing load balancer (default behavior).
-- `"public" = "false"` — Provisions a private load balancer accessible only within the network.
+- `"public" = "true"` - Provisions a public-facing load balancer (default behavior).
+- `"public" = "false"` - Provisions a private load balancer accessible only within the network.
 
 When running outside a cloud environment, the `public` parameter is not used by the underlying infrastructure but should still be set. For services where a network is automatically created, toggling between `public` and `private` triggers the creation of a new load balancer resource
 which may be undesired.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -10,7 +10,7 @@ description: |-
 
 Creates and manages a data service resource. The `network` attribute is optional; if omitted, a network resource is automatically created. Compute sizing (CPU/memory) is driven by the `architecture` preset in `config`.
 
-The `capacity` block only exposes `storage`. It is optional — if omitted, the backend assigns a default value — and the value you set is distributed across all the components that make up the service in predetermined proportions.
+The `capacity` block only exposes `storage`. It is optional - if omitted, the backend assigns a default value - and the value you set is distributed across all the components that make up the service in predetermined proportions.
 
 ~> If resource creation fails (the resource enters `ERROR` state), the provider will fail immediately with an error. It does not wait for a timeout.
 
@@ -44,7 +44,7 @@ data "ametnes_location" "location" {
 }
 
 # Provision multiple services using a map for stable resource addressing.
-# The network attribute is omitted — a network will be auto-created.
+# The network attribute is omitted - a network will be auto-created.
 locals {
   services = {
     sentry = { kind = "sentry:26.2", kind_name = "sentry", storage = 30, architecture = "Starter" },
@@ -154,14 +154,14 @@ resource "ametnes_service" "service" {
 }
 ```
 
-> Note: the timeout is not a deployment deadline — it only bounds how long Terraform waits. Deployments that the agent completes more quickly will still finish as soon as the resource becomes ready.
+> Note: the timeout is not a deployment deadline - it only bounds how long Terraform waits. Deployments that the agent completes more quickly will still finish as soon as the resource becomes ready.
 
 <a id="nestedblock--capacity"></a>
 ### Nested Schema for `capacity`
 
 Optional:
 
-- `storage` (Number) Storage, in (Gb) unit counts, for your data service resource. Optional — if omitted, the backend assigns a default value. The value is distributed across all components that make up the service in predetermined proportions.
+- `storage` (Number) Storage, in (Gb) unit counts, for your data service resource. Optional - if omitted, the backend assigns a default value. The value is distributed across all components that make up the service in predetermined proportions.
 
 
 <a id="nestedatt--connections"></a>

--- a/examples/provider/example-resources.tf
+++ b/examples/provider/example-resources.tf
@@ -10,7 +10,7 @@ data "ametnes_project" "project" {
 }
 
 # Provision multiple services using a map for stable resource addressing.
-# The network attribute is optional — if omitted, a network is auto-created.
+# The network attribute is optional - if omitted, a network is auto-created.
 locals {
   services = {
     sentry = { kind = "sentry:26.2", kind_name = "sentry", storage = 30, architecture = "Starter" },


### PR DESCRIPTION
- add `version: 2` to .goreleaser.yml (GoReleaser v2 requires it)
- replace `changelog.skip` with `changelog.disable` (v2 rename)
- replace em-dashes with hyphens across README, CHANGELOG, docs and
  the storage attribute description